### PR TITLE
iOS support.

### DIFF
--- a/vrchat.jordo.easyquestswitch/Editor/EQS_PropertyDrawers.cs
+++ b/vrchat.jordo.easyquestswitch/Editor/EQS_PropertyDrawers.cs
@@ -12,13 +12,15 @@ namespace EasyQuestSwitch.Fields
     public class BaseDrawer : PropertyDrawer
     {
         protected float labelRatio = 0.25f;
-        protected float optionRatio = 0.735f/2;
-        protected float dividerRatio = 0.02f;
+        protected float optionRatio = 0.735f/3;
+        protected float dividerRatio = 0.0075f;
 
         protected Rect labelRect;
         protected Rect optionARect;
         protected Rect dividerRect;
         protected Rect optionBRect;
+        protected Rect dividerRect2;
+        protected Rect optionCRect;
 
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
         {
@@ -30,8 +32,14 @@ namespace EasyQuestSwitch.Fields
             dividerRect.x += labelRect.width + optionARect.width;
             optionBRect = optionARect;
             optionBRect.x += optionARect.width + dividerRect.width;
+            dividerRect2 = dividerRect;
             dividerRect.x += dividerRect.width / 2;
             dividerRect.width = 1;
+            dividerRect2.x += optionBRect.width + dividerRect2.width;
+            dividerRect2.x += dividerRect2.width / 2;
+            optionCRect = optionBRect;
+            optionCRect.x += optionBRect.width + dividerRect2.width;
+            dividerRect2.width = 1;
         }
 
         public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
@@ -56,6 +64,8 @@ namespace EasyQuestSwitch.Fields
             EditorGUI.LabelField(optionARect, "PC");
             EditorGUI.DrawRect(dividerRect, Color.grey);
             EditorGUI.LabelField(optionBRect, "Quest");
+            EditorGUI.DrawRect(dividerRect2, Color.grey);
+            EditorGUI.LabelField(optionCRect, "iOS");
         }
     }
 
@@ -113,11 +123,14 @@ namespace EasyQuestSwitch.Fields
 
             SerializedProperty PC = property.FindPropertyRelative("PC");
             SerializedProperty Quest = property.FindPropertyRelative("Quest");
+            SerializedProperty iOS = property.FindPropertyRelative("iOS");
 
             EditorGUI.PrefixLabel(labelRect, GUIUtility.GetControlID(FocusType.Passive), label);
             EditorGUI.PropertyField(optionARect, PC, GUIContent.none);
             EditorGUI.DrawRect(dividerRect, Color.grey);
             EditorGUI.PropertyField(optionBRect, Quest, GUIContent.none);
+            EditorGUI.DrawRect(dividerRect2, Color.grey);
+            EditorGUI.PropertyField(optionCRect, iOS, GUIContent.none);
             EditorGUI.EndProperty();
         }
     }
@@ -134,11 +147,14 @@ namespace EasyQuestSwitch.Fields
 
             SerializedProperty PC = property.FindPropertyRelative("PC");
             SerializedProperty Quest = property.FindPropertyRelative("Quest");
+            SerializedProperty iOS = property.FindPropertyRelative("iOS");
 
             EditorGUI.PrefixLabel(labelRect, GUIUtility.GetControlID(FocusType.Passive), label);
             PC.stringValue = EditorGUI.TagField(optionARect, PC.stringValue);
             EditorGUI.DrawRect(dividerRect, Color.grey);
             Quest.stringValue = EditorGUI.TagField(optionBRect, Quest.stringValue);
+            EditorGUI.DrawRect(dividerRect2, Color.grey);
+            iOS.stringValue = EditorGUI.TagField(optionCRect, iOS.stringValue);
             EditorGUI.EndProperty();
         }
     }
@@ -155,11 +171,14 @@ namespace EasyQuestSwitch.Fields
 
             SerializedProperty PC = property.FindPropertyRelative("PC");
             SerializedProperty Quest = property.FindPropertyRelative("Quest");
+            SerializedProperty iOS = property.FindPropertyRelative("iOS");
 
             EditorGUI.PrefixLabel(labelRect, GUIUtility.GetControlID(FocusType.Passive), label);
             PC.intValue = EditorGUI.LayerField(optionARect, PC.intValue);
             EditorGUI.DrawRect(dividerRect, Color.grey);
             Quest.intValue = EditorGUI.LayerField(optionBRect, Quest.intValue);
+            EditorGUI.DrawRect(dividerRect2, Color.grey);
+            iOS.intValue = EditorGUI.LayerField(optionCRect, iOS.intValue);
             EditorGUI.EndProperty();
         }
     }
@@ -176,11 +195,14 @@ namespace EasyQuestSwitch.Fields
 
             SerializedProperty PC = property.FindPropertyRelative("PC");
             SerializedProperty Quest = property.FindPropertyRelative("Quest");
+            SerializedProperty iOS = property.FindPropertyRelative("iOS");
 
             EditorGUI.PrefixLabel(labelRect, GUIUtility.GetControlID(FocusType.Passive), label);
             PC.intValue = EditorGUI.MaskField(optionARect, PC.intValue, PC.enumDisplayNames);
             EditorGUI.DrawRect(dividerRect, Color.grey);
             Quest.intValue = EditorGUI.MaskField(optionBRect, Quest.intValue, Quest.enumDisplayNames);
+            EditorGUI.DrawRect(dividerRect2, Color.grey);
+            iOS.intValue = EditorGUI.MaskField(optionCRect, iOS.intValue, iOS.enumDisplayNames);
             EditorGUI.EndProperty();
         }
     }

--- a/vrchat.jordo.easyquestswitch/Editor/EQS_Window.cs
+++ b/vrchat.jordo.easyquestswitch/Editor/EQS_Window.cs
@@ -61,6 +61,7 @@ namespace EasyQuestSwitch
                     headerBG.SetPixel(0, 0, new Color(0.15f, 0.5f, 0.75f));
                     break;
                 case BuildTarget.Android:
+                case BuildTarget.iOS:
                     headerBG.SetPixel(0, 0, new Color(0, 0.8f, 0.3f));
                     break;
                 default:
@@ -440,6 +441,7 @@ namespace EasyQuestSwitch
                     {
                         if (GUILayout.Button(EQS_Localization.Current.SettingsApplyPC)) data.ApplyTarget(BuildTarget.StandaloneWindows64);
                         if (GUILayout.Button(EQS_Localization.Current.SettingsApplyQuest)) data.ApplyTarget(BuildTarget.Android);
+                        if (GUILayout.Button(EQS_Localization.Current.SettingsApplyiOS)) data.ApplyTarget(BuildTarget.iOS);
                     }
                     if (GUILayout.Button(EQS_Localization.Current.SettingsRemoveEQS, GUILayout.Height(32)))
                     {

--- a/vrchat.jordo.easyquestswitch/Runtime/EQS_Data.cs
+++ b/vrchat.jordo.easyquestswitch/Runtime/EQS_Data.cs
@@ -1,4 +1,4 @@
-﻿#if UNITY_EDITOR
+#if UNITY_EDITOR
 using System;
 using System.Collections.Generic;
 using UnityEditor;
@@ -26,7 +26,12 @@ namespace EasyQuestSwitch
 
         public List<Data> Objects;
         public int version = 0;
-        private const int currentVersion = 131;
+
+        public const int UpdateFixMatsAndLights = 131;
+        public const int UpdateAddIOS = 141;
+        
+        private const int currentVersion = UpdateAddIOS;
+        
 
         public void ValidateData(int index)
         {
@@ -121,10 +126,7 @@ namespace EasyQuestSwitch
                 {
                     if (d.Type != null)
                     {
-                        if(d.Type.GetType() == typeof(Type_Material) || d.Type.GetType() == typeof(Type_Material)) 
-                        {
-                            d.Type.Setup(d.Target, version);
-                        }
+                        d.Type.Upgrade(d.Target, version);
                     }
                 }
                 version = currentVersion;

--- a/vrchat.jordo.easyquestswitch/Runtime/EQS_Data.cs
+++ b/vrchat.jordo.easyquestswitch/Runtime/EQS_Data.cs
@@ -150,7 +150,7 @@ namespace EasyQuestSwitch
         
         public void ApplyTarget(BuildTarget newTarget)
         {
-            if(newTarget == BuildTarget.StandaloneWindows64 || newTarget == BuildTarget.Android)
+            if(newTarget == BuildTarget.StandaloneWindows64 || newTarget == BuildTarget.Android || newTarget == BuildTarget.iOS)
             {
                 for(int i = 0; i < Objects.Count; i++)
                 {

--- a/vrchat.jordo.easyquestswitch/Runtime/EQS_Localization.cs
+++ b/vrchat.jordo.easyquestswitch/Runtime/EQS_Localization.cs
@@ -40,6 +40,7 @@ namespace EasyQuestSwitch
             public string SettingsListFormat;
             public string[] SettingsListFormatArray;
             public string SettingsApplyPC;
+            public string SettingsApplyiOS;
             public string SettingsApplyQuest;
             public string SettingsRemoveEQS;
             public string SettingsCacheWarning;

--- a/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/EQS_Fields.cs
+++ b/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/EQS_Fields.cs
@@ -14,10 +14,11 @@ namespace EasyQuestSwitch.Fields
     {
         public T PC;
         public T Quest;
+        public T iOS;
 
         public void Setup(T obj)
         {
-            PC = Quest = obj;
+            PC = Quest = iOS = obj;
         }
 
         public T Get(BuildTarget buildTarget)
@@ -28,6 +29,8 @@ namespace EasyQuestSwitch.Fields
                     return PC;
                 case BuildTarget.Android:
                     return Quest;
+                case BuildTarget.iOS:
+                    return iOS;
                 default:
                     return default(T);
             }

--- a/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/Type_Animator.cs
+++ b/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/Type_Animator.cs
@@ -22,6 +22,16 @@ namespace EasyQuestSwitch.Types
             CullingMode.Setup(component.cullingMode);
         }
 
+        public override void Upgrade(Object type, int currentVersion)
+        {
+            base.Upgrade(type, currentVersion);
+            if (currentVersion < EQS_Data.UpdateAddIOS)
+            {
+                Controller.iOS = Controller.Quest;
+                CullingMode.iOS = CullingMode.Quest;
+            }
+        }
+
         public override void Process(Object type, BuildTarget buildTarget)
         {
             base.Process(type, buildTarget);

--- a/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/Type_AudioSource.cs
+++ b/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/Type_AudioSource.cs
@@ -32,6 +32,21 @@ namespace EasyQuestSwitch.Types
             BypassReverbZones.Setup(component.bypassReverbZones);
         }
 
+        public override void Upgrade(Object type, int currentVersion)
+        {
+            base.Upgrade(type, currentVersion);
+            if (currentVersion < EQS_Data.UpdateAddIOS)
+            {
+                AudioClip.iOS = AudioClip.Quest;
+                Volume.iOS = Volume.Quest;
+                SpatialBlend.iOS = SpatialBlend.Quest;
+                ReverbZoneMix.iOS = ReverbZoneMix.Quest;
+                BypassEffects.iOS = BypassEffects.Quest;
+                BypassListenreEffects.iOS = BypassListenreEffects.Quest;
+                BypassReverbZones.iOS = BypassReverbZones.Quest;
+            }
+        }
+
         public override void Process(Object type, BuildTarget buildTarget)
         {
             base.Process(type, buildTarget);

--- a/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/Type_Base.cs
+++ b/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/Type_Base.cs
@@ -1,4 +1,4 @@
-﻿#if UNITY_EDITOR
+#if UNITY_EDITOR
 using UnityEditor;
 using UnityEngine;
 
@@ -9,8 +9,7 @@ namespace EasyQuestSwitch.Types
     {
         public abstract void Setup(Object type);
         
-        // Override without calling base to setup custom migration
-        public virtual void Setup(Object type, int currentVersion) => Setup(type);
+        public abstract void Upgrade(Object type, int currentVersion);
         
         public abstract void Process(Object type, BuildTarget buildTarget);
     }

--- a/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/Type_Behaviour.cs
+++ b/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/Type_Behaviour.cs
@@ -19,6 +19,14 @@ namespace EasyQuestSwitch.Types
             Enabled.Setup(component.enabled);
         }
 
+        public override void Upgrade(Object type, int currentVersion)
+        {
+            if (currentVersion < EQS_Data.UpdateAddIOS)
+            {
+                Enabled.iOS = Enabled.Quest;
+            }
+        }
+
         public override void Process(Object type, BuildTarget buildTarget)
         {
             Behaviour component = (Behaviour)type;

--- a/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/Type_BoxCollider.cs
+++ b/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/Type_BoxCollider.cs
@@ -22,6 +22,17 @@ namespace EasyQuestSwitch.Types
             Center.Setup(component.center);
         }
 
+        public override void Upgrade(Object type, int currentVersion)
+        {
+            base.Upgrade(type, currentVersion);
+
+            if (currentVersion < EQS_Data.UpdateAddIOS)
+            {
+                Size.iOS = Size.Quest;
+                Center.iOS = Center.Quest;
+            }
+        }
+
         public override void Process(Object type, BuildTarget buildTarget)
         {
             base.Process(type, buildTarget);

--- a/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/Type_Camera.cs
+++ b/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/Type_Camera.cs
@@ -26,6 +26,18 @@ namespace EasyQuestSwitch.Types
             OcclusionCulling.Setup(component.useOcclusionCulling);
         }
 
+        public override void Upgrade(Object type, int currentVersion)
+        {
+            base.Upgrade(type, currentVersion);
+            if (currentVersion < EQS_Data.UpdateAddIOS)
+            {
+                ClippingPlaneNear.iOS = ClippingPlaneNear.Quest;
+                ClippingPlaneFar.iOS = ClippingPlaneFar.Quest;
+                TargetTexture.iOS = TargetTexture.Quest;
+                OcclusionCulling.iOS = OcclusionCulling.Quest;
+            }
+        }
+
         public override void Process(Object type, BuildTarget buildTarget)
         {
             base.Process(type, buildTarget);

--- a/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/Type_CanvasScaler.cs
+++ b/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/Type_CanvasScaler.cs
@@ -23,6 +23,16 @@ namespace EasyQuestSwitch.Types
             ReferencePixelsPerUnit.Setup(component.referencePixelsPerUnit);
         }
 
+        public override void Upgrade(Object type, int currentVersion)
+        {
+            base.Upgrade(type, currentVersion);
+            if (currentVersion < EQS_Data.UpdateAddIOS)
+            {
+                ScaleFactor.iOS = ScaleFactor.Quest;
+                ReferencePixelsPerUnit.iOS = ReferencePixelsPerUnit.Quest;
+            }
+        }
+
         public override void Process(Object type, BuildTarget buildTarget)
         {
             base.Process(type, buildTarget);

--- a/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/Type_Collider.cs
+++ b/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/Type_Collider.cs
@@ -20,6 +20,15 @@ namespace EasyQuestSwitch.Types
             Enabled.Setup(component.enabled);
         }
 
+        public override void Upgrade(Object type, int currentVersion)
+        {
+            if (currentVersion < EQS_Data.UpdateAddIOS)
+            {
+                Enabled.iOS = Enabled.Quest;
+                IsTrigger.iOS = IsTrigger.Quest;
+            }
+        }
+
         public override void Process(Object type, BuildTarget buildTarget)
         {
             Collider component = (Collider)type;

--- a/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/Type_GameObject.cs
+++ b/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/Type_GameObject.cs
@@ -25,6 +25,17 @@ namespace EasyQuestSwitch.Types
             StaticEditorFlags.Setup(GameObjectUtility.GetStaticEditorFlags(component));
         }
 
+        public override void Upgrade(Object type, int currentVersion)
+        {
+            if (currentVersion < EQS_Data.UpdateAddIOS)
+            {
+                Active.iOS = Active.Quest;
+                Tag.iOS = Tag.Quest;
+                Layer.iOS = Layer.Quest;
+                StaticEditorFlags.iOS = StaticEditorFlags.Quest;
+            }
+        }
+
         public override void Process(Object type, BuildTarget buildTarget)
         {
             GameObject component = (GameObject)type;

--- a/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/Type_Image.cs
+++ b/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/Type_Image.cs
@@ -25,6 +25,17 @@ namespace EasyQuestSwitch.Types
             Material.Setup(component.material);
         }
 
+        public override void Upgrade(Object type, int currentVersion)
+        {
+            base.Upgrade(type, currentVersion);
+            if (currentVersion < EQS_Data.UpdateAddIOS)
+            {
+                Sprite.iOS = Sprite.Quest;
+                Color.iOS = Color.Quest;
+                Material.iOS = Material.Quest;
+            }
+        }
+
         public override void Process(Object type, BuildTarget buildTarget)
         {
             base.Process(type, buildTarget);

--- a/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/Type_LODGroup.cs
+++ b/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/Type_LODGroup.cs
@@ -36,6 +36,27 @@ namespace EasyQuestSwitch.Types
             }
         }
 
+        public override void Upgrade(Object type, int currentVersion)
+        {
+
+            if (currentVersion < EQS_Data.UpdateAddIOS)
+            {
+                Enabled.iOS = Enabled.Quest;
+                FadeMode.iOS = FadeMode.Quest;
+                AnimateCrossFading.iOS = AnimateCrossFading.Quest;
+                foreach (var sharedFloat in Percentage)
+                {
+                    sharedFloat.iOS = sharedFloat.Quest;
+                }
+
+                foreach (var sharedFloat in FadeTransitionWidth)
+                {
+                    sharedFloat.iOS = sharedFloat.Quest;
+                }
+            }
+
+        }
+
         public override void Process(Object type, BuildTarget buildTarget)
         {
             LODGroup component = (LODGroup)type;

--- a/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/Type_Light.cs
+++ b/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/Type_Light.cs
@@ -34,14 +34,30 @@ namespace EasyQuestSwitch.Types
             RenderMode.Setup(component.renderMode);
         }
 
-        public override void Setup(Object type, int currentVersion)
+        public override void Upgrade(Object type, int currentVersion)
         {
+            base.Upgrade(type, currentVersion);
             Light component = (Light)type;
-            if (currentVersion == 0) // 0 -> 131 upgrade
+            // Bug: This upgrade code was never called originally.
+            // This is due to a typo in a conditional that snuck in.
+            // It's probably too late to fix it this way.
+            if (currentVersion < EQS_Data.UpdateFixMatsAndLights)
             {
                 LightType.Setup(component.type);
                 Range.Setup(component.range);
                 RenderMode.Setup(component.renderMode);
+            }
+
+            if (currentVersion < EQS_Data.UpdateAddIOS)
+            {
+                LightType.iOS = LightType.Quest;
+                Range.iOS = Range.Quest;
+                Color.iOS = Color.Quest;
+                Mode.iOS = Mode.Quest;
+                Intensity.iOS = Intensity.Quest;
+                IndirectMultiplier.iOS = IndirectMultiplier.Quest;
+                ShadowType.iOS = ShadowType.Quest;
+                RenderMode.iOS = RenderMode.Quest;
             }
         }
 

--- a/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/Type_Material.cs
+++ b/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/Type_Material.cs
@@ -26,13 +26,21 @@ namespace EasyQuestSwitch.Types
             GPUInstancing.Setup(material.enableInstancing);
         }
 
-        public override void Setup(Object type, int currentVersion)
+        public override void Upgrade(Object type, int currentVersion)
         {
             Material material = (Material)type;
-            if (currentVersion == 0) // 0 -> 131 upgrade
+            if (currentVersion < EQS_Data.UpdateFixMatsAndLights)
             {
                 MainColor.Setup(material.color);
                 GPUInstancing.Setup(material.enableInstancing);
+            }
+
+            if (currentVersion < EQS_Data.UpdateAddIOS)
+            {
+                Shader.iOS = Shader.Quest;
+                MainColor.iOS = MainColor.Quest;
+                GPUInstancing.iOS = GPUInstancing.Quest;
+                ShaderPath.iOS = ShaderPath.Quest;
             }
         }
 

--- a/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/Type_Material.cs
+++ b/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/Type_Material.cs
@@ -49,6 +49,9 @@ namespace EasyQuestSwitch.Types
                     case BuildTarget.Android:
                         ShaderPath.Quest = Shader.Get(buildTarget).name;
                         break;
+                    case BuildTarget.iOS:
+                        ShaderPath.iOS = Shader.Get(buildTarget).name;
+                        break;
                 }
             }
             else if(Shader.Get(buildTarget) == null && !string.IsNullOrEmpty(ShaderPath.Get(buildTarget)))
@@ -60,6 +63,9 @@ namespace EasyQuestSwitch.Types
                         break;
                     case BuildTarget.Android:
                         Shader.Quest = UnityEngine.Shader.Find(ShaderPath.Quest);
+                        break;
+                    case BuildTarget.iOS:
+                        Shader.iOS = UnityEngine.Shader.Find(ShaderPath.iOS);
                         break;
                 }
             }

--- a/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/Type_MeshCollider.cs
+++ b/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/Type_MeshCollider.cs
@@ -22,6 +22,16 @@ namespace EasyQuestSwitch.Types
             SharedMesh.Setup(component.sharedMesh);
         }
 
+        public override void Upgrade(Object type, int currentVersion)
+        {
+            base.Upgrade(type, currentVersion);
+            if (currentVersion < EQS_Data.UpdateAddIOS)
+            {
+                Convex.iOS = Convex.Quest;
+                SharedMesh.iOS = SharedMesh.Quest;
+            }
+        }
+
         public override void Process(Object type, BuildTarget buildTarget)
         {
             MeshCollider component = (MeshCollider)type;

--- a/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/Type_MeshFilter.cs
+++ b/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/Type_MeshFilter.cs
@@ -19,6 +19,14 @@ namespace EasyQuestSwitch.Types
             Mesh.Setup(component.sharedMesh);
         }
 
+        public override void Upgrade(Object type, int currentVersion)
+        {
+            if (currentVersion < EQS_Data.UpdateAddIOS)
+            {
+                Mesh.iOS = Mesh.Quest;
+            }
+        }
+
         public override void Process(Object type, BuildTarget buildTarget)
         {
             MeshFilter component = (MeshFilter)type;

--- a/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/Type_RawImage.cs
+++ b/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/Type_RawImage.cs
@@ -25,6 +25,17 @@ namespace EasyQuestSwitch.Types
             Material.Setup(component.material);
         }
 
+        public override void Upgrade(Object type, int currentVersion)
+        {
+            base.Upgrade(type, currentVersion);
+            if (currentVersion < EQS_Data.UpdateAddIOS)
+            {
+                Texture.iOS = Texture.Quest;
+                Color.iOS = Color.Quest;
+                Material.iOS = Material.Quest;
+            }
+        }
+
         public override void Process(Object type, BuildTarget buildTarget)
         {
             base.Process(type, buildTarget);

--- a/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/Type_ReflectionProbe.cs
+++ b/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/Type_ReflectionProbe.cs
@@ -31,6 +31,20 @@ namespace EasyQuestSwitch.Types
             Resolution.Setup((ReflectionProbeResolution)component.resolution);
         }
 
+        public override void Upgrade(Object type, int currentVersion)
+        {
+            base.Upgrade(type, currentVersion);
+            if (currentVersion < EQS_Data.UpdateAddIOS)
+            {
+                ReflectionProbeType.iOS = ReflectionProbeType.Quest;
+                Cubemap.iOS = Cubemap.Quest;
+                Importance.iOS = Importance.Quest;
+                Intensity.iOS = Intensity.Quest;
+                BoxProjection.iOS = BoxProjection.Quest;
+                Resolution.iOS = Resolution.Quest;
+            }
+        }
+
         public override void Process(Object type, BuildTarget buildTarget)
         {
             base.Process(type, buildTarget);

--- a/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/Type_RenderTexture.cs
+++ b/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/Type_RenderTexture.cs
@@ -28,6 +28,18 @@ namespace EasyQuestSwitch.Types
             FilterMode.Setup(component.filterMode);
         }
 
+        public override void Upgrade(Object type, int currentVersion)
+        {
+            if (currentVersion < EQS_Data.UpdateAddIOS)
+            {
+                Size.iOS = Size.Quest;
+                AntiAliasing.iOS = AntiAliasing.Quest;
+                DepthBuffer.iOS = DepthBuffer.Quest;
+                EnableMipMaps.iOS = EnableMipMaps.Quest;
+                FilterMode.iOS = FilterMode.Quest;
+            }
+        }
+
         public override void Process(Object type, BuildTarget buildTarget)
         {
             RenderTexture component = (RenderTexture)type;

--- a/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/Type_Renderer.cs
+++ b/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/Type_Renderer.cs
@@ -39,6 +39,24 @@ namespace EasyQuestSwitch.Types
             }
         }
 
+        public override void Upgrade(Object type, int currentVersion)
+        {
+            if (currentVersion < EQS_Data.UpdateAddIOS)
+            {
+                Enabled.iOS = Enabled.Quest;
+                LightProbes.iOS = LightProbes.Quest;
+                AnchorOverride.iOS = AnchorOverride.Quest;
+                ReflectionProbes.iOS = ReflectionProbes.Quest;
+                CastShadows.iOS = CastShadows.Quest;
+                ReceiveShadows.iOS = ReceiveShadows.Quest;
+                DynamicOccluded.iOS = DynamicOccluded.Quest;
+                foreach (var sharedMaterial in Materials)
+                {
+                    sharedMaterial.iOS = sharedMaterial.Quest;
+                }
+            }
+        }
+
         public override void Process(Object type, BuildTarget buildTarget)
         {
 

--- a/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/Type_SkinnedMeshRenderer.cs
+++ b/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/Type_SkinnedMeshRenderer.cs
@@ -22,6 +22,16 @@ namespace EasyQuestSwitch.Types
             UpdateWhenOffscreen.Setup(component.updateWhenOffscreen);
         }
 
+        public override void Upgrade(Object type, int currentVersion)
+        {
+            base.Upgrade(type, currentVersion);
+            if (currentVersion < EQS_Data.UpdateAddIOS)
+            {
+                Mesh.iOS = Mesh.Quest;
+                UpdateWhenOffscreen.iOS = UpdateWhenOffscreen.Quest;
+            }
+        }
+
         public override void Process(Object type, BuildTarget buildTarget)
         {
             base.Process(type, buildTarget);

--- a/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/Type_SphereCollider.cs
+++ b/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/Type_SphereCollider.cs
@@ -22,6 +22,16 @@ namespace EasyQuestSwitch.Types
             Radius.Setup(component.radius);
         }
 
+        public override void Upgrade(Object type, int currentVersion)
+        {
+            base.Upgrade(type, currentVersion);
+            if (currentVersion < EQS_Data.UpdateAddIOS)
+            {
+                Center.iOS = Center.Quest;
+                Radius.iOS = Radius.Quest;
+            }
+        }
+
         public override void Process(Object type, BuildTarget buildTarget)
         {
             base.Process(type, buildTarget);

--- a/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/Type_SpriteRenderer.cs
+++ b/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/Type_SpriteRenderer.cs
@@ -23,6 +23,16 @@ namespace EasyQuestSwitch.Types
             Material.Setup(component.material);
         }
 
+        public override void Upgrade(Object type, int currentVersion)
+        {
+            if (currentVersion < EQS_Data.UpdateAddIOS)
+            {
+                Sprite.iOS = Sprite.Quest;
+                Color.iOS = Color.Quest;
+                Material.iOS = Material.Quest;
+            }
+        }
+
         public override void Process(Object type, BuildTarget buildTarget)
         {
             SpriteRenderer component = (SpriteRenderer)type;

--- a/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/Type_Transform.cs
+++ b/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/Type_Transform.cs
@@ -23,6 +23,16 @@ namespace EasyQuestSwitch.Types
             Scale.Setup(component.localScale);
         }
 
+        public override void Upgrade(Object type, int currentVersion)
+        {
+            if (currentVersion < EQS_Data.UpdateAddIOS)
+            {
+                Position.iOS = Position.Quest;
+                Rotation.iOS = Rotation.Quest;
+                Scale.iOS = Scale.Quest;
+            }
+        }
+
         public override void Process(Object type, BuildTarget buildTarget)
         {
             Transform component = (Transform)type;

--- a/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/VRC/Type_VRC_MirrorReflection_SDK2.cs
+++ b/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/VRC/Type_VRC_MirrorReflection_SDK2.cs
@@ -25,6 +25,17 @@ namespace EasyQuestSwitch.Types
             ReflectLayers.Setup(component.m_ReflectLayers);
         }
 
+        public override void Upgrade(Object type, int currentVersion)
+        {
+            base.Upgrade(type, currentVersion);
+            if (currentVersion < EQS_Data.UpdateAddIOS)
+            {
+                DisablePixelLights.iOS = DisablePixelLights.Quest;
+                TurnOffMirrorOcclusion.iOS = TurnOffMirrorOcclusion.Quest;
+                ReflectLayers.iOS = ReflectLayers.Quest;
+            }
+        }
+
         public override void Process(Object type, BuildTarget buildTarget)
         {
             base.Process(type, buildTarget);

--- a/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/VRC/Type_VRC_MirrorReflection_SDK3.cs
+++ b/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/VRC/Type_VRC_MirrorReflection_SDK3.cs
@@ -24,6 +24,15 @@ namespace EasyQuestSwitch.Types
             TurnOffMirrorOcclusion.Setup(component.TurnOffMirrorOcclusion);
             ReflectLayers.Setup(component.m_ReflectLayers);
         }
+        public override void Upgrade(Object type, int currentVersion)
+        {
+            if (currentVersion < EQS_Data.UpdateAddIOS)
+            {
+                DisablePixelLights.iOS = DisablePixelLights.Quest;
+                TurnOffMirrorOcclusion.iOS = TurnOffMirrorOcclusion.Quest;
+                ReflectLayers.iOS = ReflectLayers.Quest;
+            }
+        }
 
         public override void Process(Object type, BuildTarget buildTarget)
         {

--- a/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/VRC/Type_VRC_SpatialAudioSource_SDK2.cs
+++ b/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/VRC/Type_VRC_SpatialAudioSource_SDK2.cs
@@ -1,8 +1,10 @@
 #if UNITY_EDITOR && VRC_SDK_VRCSDK2
+using System;
 using UnityEditor;
 using UnityEngine;
 using VRCSDK2;
 using EasyQuestSwitch.Fields;
+using Object = UnityEngine.Object;
 
 namespace EasyQuestSwitch.Types
 {
@@ -26,6 +28,18 @@ namespace EasyQuestSwitch.Types
             Near.Setup(component.Near);
             VolumetricRadius.Setup(component.VolumetricRadius);
             EnableSpatialization.Setup(component.EnableSpatialization);
+        }
+
+        public override void Upgrade(Object type, int currentVersion)
+        {
+            if (currentVersion < EQS_Data.UpdateAddIOS)
+            {
+                Gain.iOS = Gain.Quest;
+                Far.iOS = Far.Quest;
+                Near.iOS = Near.Quest;
+                VolumetricRadius.iOS = VolumetricRadius.Quest;
+                EnableSpatialization.iOS = EnableSpatialization.Quest;
+            }
         }
 
         public override void Process(Object type, BuildTarget buildTarget)

--- a/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/VRC/Type_VRC_SpatialAudioSource_SDK3.cs
+++ b/vrchat.jordo.easyquestswitch/Runtime/EQS_Types/VRC/Type_VRC_SpatialAudioSource_SDK3.cs
@@ -32,6 +32,18 @@ namespace EasyQuestSwitch.Types
             EnableSpatialization.Setup(component.EnableSpatialization);
         }
 
+        public override void Upgrade(Object type, int currentVersion)
+        {
+            if (currentVersion < EQS_Data.UpdateAddIOS)
+            {
+                Gain.iOS = Gain.Quest;
+                Far.iOS = Far.Quest;
+                Near.iOS = Near.Quest;
+                VolumetricRadius.iOS = VolumetricRadius.Quest;
+                EnableSpatialization.iOS = EnableSpatialization.Quest;
+            }
+        }
+
         public override void Process(Object type, BuildTarget buildTarget)
         {
             VRCSpatialAudioSource component = (VRCSpatialAudioSource)type;

--- a/vrchat.jordo.easyquestswitch/Runtime/Resources/EQS_Localizations/cn.json
+++ b/vrchat.jordo.easyquestswitch/Runtime/Resources/EQS_Localizations/cn.json
@@ -7,6 +7,7 @@
 	"SettingsListFormat": "列表格式",
 	"SettingsListFormatArray": [ "Simple (较快)", "Reorderable (较慢)" ],
 	"SettingsApplyPC": "强制应用PC设置",
+	"SettingsApplyiOS": "强制应用iOS设置",
 	"SettingsApplyQuest": "强制应用Quest设置",
 	"SettingsRemoveEQS": "从场景中从移除 Easy Quest Switch",
 	"SettingsCacheWarning": "缓存服务器未启用，您可能需要较长的切换时间！最好将其设置为本地或远程。（远程操作需要额外的步骤）",

--- a/vrchat.jordo.easyquestswitch/Runtime/Resources/EQS_Localizations/en.json
+++ b/vrchat.jordo.easyquestswitch/Runtime/Resources/EQS_Localizations/en.json
@@ -7,6 +7,7 @@
 	"SettingsListFormat": "List format",
 	"SettingsListFormatArray": [ "Simple (faster)", "Reorderable (slower)" ],
 	"SettingsApplyPC": "Force apply PC settings",
+	"SettingsApplyiOS": "Force apply iOS settings",
 	"SettingsApplyQuest": "Force apply Quest settings",
 	"SettingsRemoveEQS": "Remove Easy Quest Switch from the scene",
 	"SettingsCacheWarning": "Your cache server is not enabled, you may experience long switching times! It is best to set it to local or remote. (Remote requires additional steps)",

--- a/vrchat.jordo.easyquestswitch/Runtime/Resources/EQS_Localizations/es.json
+++ b/vrchat.jordo.easyquestswitch/Runtime/Resources/EQS_Localizations/es.json
@@ -7,6 +7,7 @@
 	"SettingsListFormat": "Formato de lista",
 	"SettingsListFormatArray": [ "Simple (rápido)", "Reordenable (lento)" ],
 	"SettingsApplyPC": "Forzar aplicación de ajustes de PC",
+	"SettingsApplyiOS": "Forzar aplicación de ajustes de iOS",
 	"SettingsApplyQuest": "Forzar aplicación de ajustes de Quest",
 	"SettingsRemoveEQS": "Remover Easy Quest Switch de la escena",
 	"SettingsCacheWarning": "Tu servidor de cache no está habilitado, puedes experimentar largos tiempos de cambio! Es mejor establecerlo a local o remoto. (Remoto requiere pasos adicionales)",

--- a/vrchat.jordo.easyquestswitch/Runtime/Resources/EQS_Localizations/fr.json
+++ b/vrchat.jordo.easyquestswitch/Runtime/Resources/EQS_Localizations/fr.json
@@ -7,6 +7,7 @@
 	"SettingsListFormat": "Format de la liste",
 	"SettingsListFormatArray": [ "Simple (rapide)", "Re-organisable (lent)" ],
 	"SettingsApplyPC": "Appliquer les paramètres PC de force",
+	"SettingsApplyiOS": "Appliquer les paramètres iOS de force",
 	"SettingsApplyQuest": "Appliquer les paramètres Quest de force",
 	"SettingsRemoveEQS": "Supprimer Easy Quest Switch de la scène",
 	"SettingsCacheWarning": "Votre serveur cache n'est pas activé, il est possible que vous ayez un temps de changement de plateforme cible plus long! Il est préférable de le configurer en local ou remote. (Remote requiert des étapes supplémentaires)",

--- a/vrchat.jordo.easyquestswitch/Runtime/Resources/EQS_Localizations/jp.json
+++ b/vrchat.jordo.easyquestswitch/Runtime/Resources/EQS_Localizations/jp.json
@@ -7,6 +7,7 @@
 	"SettingsListFormat": "UIの形式",
 	"SettingsListFormatArray": [ "簡易 (高速)", "順番変更可能 (低速)" ],
 	"SettingsApplyPC": "PCの設定を強制的に適用",
+	"SettingsApplyiOS": "iOSの設定を強制的に適用",
 	"SettingsApplyQuest": "Questの設定を強制的に適用",
 	"SettingsRemoveEQS": "「EasyQuestSwitch」をSceneから削除",
 	"SettingsCacheWarning": "キャッシュサーバーが有効になっていない場合、切り替え時間が長くなる可能性があります。\nLocalかRemoteに設定するのがおすすめです。\n(Remoteの場合は追加の手順が必要です)",


### PR DESCRIPTION
Add basic iOS support.

This does not yet handle migrating. I'm not sure what the best way to do this is, given the data structure change is in SharedObject.

It's probably possible to scan through the objects with reflection, but if not, it might be necessary to add migration code to all types to initialize the fields.

Probably best to initialize it from the Quest values.